### PR TITLE
Reduce labels and label values

### DIFF
--- a/src/apps/common/apputils.c
+++ b/src/apps/common/apputils.c
@@ -529,24 +529,10 @@ const char *socket_type_name(SOCKET_TYPE st) {
 }
 
 const char *duration_name(unsigned long duration) {
-    if (duration < 1) {
-        return "1sec";
-    } else if (duration < 10) {
-        return "10sec";
-    } else if (duration < 30) {
-        return "30sec";
-    } else if (duration < 60) {
+    if (duration < 60) {
         return "1min";
     } else if (duration < 600) {
         return "10mins";
-    } else if (duration < 1800) {
-        return "30mins";
-    } else if (duration < 3600) {
-        return "1hr";
-    } else if (duration < 14400) {
-        return "4hrs";
-    } else if (duration < 43200) {
-        return "12hrs";
     } else if (duration < 86400) {
         return "24hrs";
     } else {
@@ -555,22 +541,10 @@ const char *duration_name(unsigned long duration) {
 }
 
 const char *rate_name(unsigned long rate_kbps) {
-    if (rate_kbps < 1) {
-        return "1kbps";
-    } else if (rate_kbps < 10) {
-        return "10kbps";
-    } else if (rate_kbps < 50) {
+    if (rate_kbps < 50) {
         return "50kbps";
-    } else if (rate_kbps < 100) {
-        return "100kbps";
-    } else if (rate_kbps < 500) {
-        return "500kbps";
-    } else if (rate_kbps < 1000) {
-        return "1000kbps";
     } else if (rate_kbps < 2500) {
         return "2500kbps";
-    } else if (rate_kbps < 5000) {
-        return "5000kbps";
     } else {
         return "10000kbps";
     }

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -3657,12 +3657,10 @@ void turn_report_allocation_delete(void *a, SOCKET_TYPE socket_type, int family)
           }
           turn_time_t ct = get_turn_server_time(server) - ss->start_time;
           const uint32_t byte_to_kilobit = 125;
-          uint64_t received_rate_kbps = ss->received_rate / byte_to_kilobit;
           uint64_t sent_rate_kbps = ss->sent_rate / byte_to_kilobit;
           prom_dec_allocation(socket_type,
                               family,
                               (unsigned long)ct,
-                              (unsigned long)received_rate_kbps,
                               (unsigned long)sent_rate_kbps);
         }
 #endif

--- a/src/apps/relay/prom_server.c
+++ b/src/apps/relay/prom_server.c
@@ -97,9 +97,9 @@ void start_prometheus_server(void) {
 
   // Create total completed session counter metric
   const char *total_sessions_labels[] =
-          {"duration", "received_rate", "sent_rate" };
+          {"duration", "sent_rate" };
   turn_total_sessions = prom_collector_registry_must_register_metric(
-      prom_counter_new("turn_total_sessions", "Represents total completed sessions", 3, total_sessions_labels));
+      prom_counter_new("turn_total_sessions", "Represents total completed sessions", 2, total_sessions_labels));
 
   // Create total allocations number gauge metric
   const char *total_allocations_labels[] = {"type", "client_addr_family"};
@@ -182,12 +182,11 @@ void prom_inc_allocation(SOCKET_TYPE type, int addr_family) {
 void prom_dec_allocation(SOCKET_TYPE type,
                          int addr_family,
                          unsigned long duration,
-                         unsigned long received_rate_kbps,
                          unsigned long sent_rate_kbps) {
   if (turn_params.prometheus == 1) {
     const char *labels[] = {socket_type_name(type), addr_family_name(addr_family) };
     prom_gauge_dec(turn_total_allocations, labels);
-    const char *total_sessions_labels[] = { duration_name(duration), rate_name(received_rate_kbps), rate_name(sent_rate_kbps) };
+    const char *total_sessions_labels[] = { duration_name(duration), rate_name(sent_rate_kbps) };
     prom_counter_add(turn_total_sessions, 1, total_sessions_labels);
   }
 }

--- a/src/apps/relay/prom_server.h
+++ b/src/apps/relay/prom_server.h
@@ -69,7 +69,6 @@ void prom_inc_allocation(SOCKET_TYPE type, int addr_family);
 void prom_dec_allocation(SOCKET_TYPE type,
                          int addr_family,
                          unsigned long duration,
-                         unsigned long received_rate_kbps,
                          unsigned long sent_rate_kbps);
 
 void prom_inc_stun_binding_request(void);


### PR DESCRIPTION
- Remove the `received_rate` label since its not being used which had 10 values.
- Reduce the number of label values for `duration` and `sent_rate` from 10 to 4 and 9 to 3 respectively